### PR TITLE
Fix optional CallbackQuery message parsing

### DIFF
--- a/src/types/CallbackQuery.cpp
+++ b/src/types/CallbackQuery.cpp
@@ -7,7 +7,7 @@ DECLARE_PARSER_FROM_JSON(CallbackQuery) {
     auto result = std::make_shared<CallbackQuery>();
     parse(data, "id", &result->id);
     result->from = parseRequired<User>(data, "from");
-    result->message = parse(data["message"]);
+    result->message = parse<MaybeInaccessibleMessage>(data, "message");
     parse(data, "inline_message_id", &result->inlineMessageId);
     parse(data, "chat_instance", &result->chatInstance);
     parse(data, "data", &result->data);


### PR DESCRIPTION
### Motivation
- Prevent a crash/DoS during JSON parsing by avoiding unchecked `nlohmann::json::operator[]` access for the optional `CallbackQuery::message` field.

### Description
- Replace the unsafe `result->message = parse(data["message"]);` with the key-aware helper `result->message = parse<MaybeInaccessibleMessage>(data, "message");` in `src/types/CallbackQuery.cpp` to yield `std::nullopt` when the key is absent.

### Testing
- No automated tests were executed because a full CMake/build could not be run due to missing `nlohmann_json` development files and restricted network access preventing dependency retrieval; the change is intentionally minimal and follows the existing key-aware parsing pattern used elsewhere.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b076f01508330bb573256e91d47c6)